### PR TITLE
Update for Anki 23.10

### DIFF
--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -167,7 +167,12 @@ def patch_anki(
 
     old_init = AnkiQt.__init__
     old_key = AnkiApp.KEY
-    old_setupAutoUpdate = AnkiQt.setupAutoUpdate
+
+    if hasattr(AnkiQt, "setup_auto_update"):
+        old_setupAutoUpdate = AnkiQt.setup_auto_update
+    else:
+        old_setupAutoUpdate = AnkiQt.setupAutoUpdate
+
     old_maybe_check_for_addon_updates = AnkiQt.maybe_check_for_addon_updates
     old_errorHandler = errors.ErrorHandler
 

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -156,6 +156,11 @@ class AnkiSession:
     def unload_profile(self, on_profile_unloaded: Optional[Callable] = None):
         """Unload current profile, optionally running a callback when profile
         unload complete"""
+
+        # Run closures before unloading collection to avoid errors due to closures
+        # trying to access the collection after it has been unloaded.
+        self._mw.taskman._on_closures_pending()
+
         if on_profile_unloaded is None:
             on_profile_unloaded = lambda *args, **kwargs: None  # noqa: E731
         self._mw.unloadProfile(on_profile_unloaded)


### PR DESCRIPTION
`pytest-anki` currently doesn't work for on Anki 23.10. This PR updates it for Anki 23.10. With these changes pytest-anki will work with the new version as well as older Anki versions it supported previously.

With the changes in this PR, all tests in this repo pass, except for three tests that test web driver functionality. We are not using this functionality of `pytest-anki` in the tests for the AnkiHub add-on, so we don't have to fix this functionality of `pytest-anki` for now.
Usage of this functionality looks like this - where a not using this anywhere:
https://github.com/ankipalace/pytest-anki/blob/538ae009947a617264ed412c7c0ceed45fccd81b/tests/test_web_debugging.py#L95-L102

I also tried running the test suite for the AnkiHub add-on with these changes to `pytest-anki` and all tests passed.

## Proposed changes
- Use `AnkiQt.setup_auto_update` instead of `AnkiQt.setupAutoUpdate` on newer Anki versions because the function was replaced in Anki.
- Run `aqt.mw.taskman._on_closures_pending()` before the `AnkiSession` fixture unloads the `Collection`. This fixes an error occurring in `aqt.deckbrowser` when using the `AnkiSession` fixture (see the **Details** section below for the error traceback).

## Details
```
tests/test_anki_session.py .Exceptions caught in Qt event loop:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/taskman.py", line 138, in _on_closures_pending
    closure()
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/taskman.py", line 82, in <lambda>
    lambda future: self.run_on_main(lambda: on_done(future))
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/operations/__init__.py", line 260, in wrapped_done
    self._success(future.result())
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/deckbrowser.py", line 152, in success
    self.__renderPage(None)
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/deckbrowser.py", line 165, in __renderPage
    tree=self._renderDeckTree(self._dueTree),
  File "/home/jakubfidler/.virtualenvs/pytest_anki_23_10/lib/python3.10/site-packages/aqt/deckbrowser.py", line 206, in _renderDeckTree
    ctx = RenderDeckNodeContext(current_deck_id=self.mw.col.conf["curDeck"])
AttributeError: 'NoneType' object has no attribute 'conf'
```