### PR TITLE
fix: increase wait signal timeout

### DIFF
--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -252,7 +252,7 @@ def anki_running(
                         set_qt_message_handler_installer(install_message_handler)
 
                         maybe_wait_for_web_debugging = qtbot.wait_signal(
-                            qt_message_matcher.match_found
+                            qt_message_matcher.match_found, timeout=15000
                         )
                     else:
                         maybe_wait_for_web_debugging = nullcontext()


### PR DESCRIPTION
#### Description

This is related to [ANKI-611](https://www.notion.so/ankihub/chore-retry-flaky-tests-using-pytest-rerunfailures-d3a409e7148d4a528f9dafce7bf42491?pvs=4). 

I investigated this issue a bit further and found out that this line is probably causing the issue (within the pytest-anki lib):
https://github.com/glutanimate/pytest-anki/blob/02f83a223f17689fddca4e4ce3f5387361af42c5/pytest_anki/_launch.py#L251-L255

The issue happens because it calls [wait_until](https://github.com/ankipalace/ankihub_addon/actions/runs/7351084513/job/20013849472) from pytest-qt which has a default timeout of 5000ms. You can see that the signal called is the same signal that is shown at the CI error message: https://github.com/ankipalace/ankihub_addon/actions/runs/7351084513/job/20013849472.

This match_found() signal is the signal that is sent when the string provided when instantiating `QtMessageMatcher` is found. You can see the usage here:
- https://github.com/ankipalace/pytest-anki/blob/e102c9d9d526ce33587fa0fcaa02b78a3e5570d5/pytest_anki/_launch.py#L232-L237

And then the signal is expected here:
- https://github.com/ankipalace/pytest-anki/blob/e102c9d9d526ce33587fa0fcaa02b78a3e5570d5/pytest_anki/_launch.py#L253-L256

This is used to determine if the anki session has started completely by waiting for a specific log message to appear.

What I think it’s happening is that the test setup is taking too long on the CI, and when that setup exceeds 5s, the waitUntil throws the [TimeoutError](https://github.com/ankipalace/ankihub_addon/actions/runs/7351084513/job/20013849472) exception.

Fortunately we're using a fork of the original lib so we can update the code and check if this is true. I've increased the timeout to 15 seconds, three times the original value.

If this does not solve the problem, we can use `pytest-rerunfailures` to just retry tests with this specific failure, as implemented by @RisingOrange here: 
- https://github.com/ankipalace/ankihub_addon/pull/856