### PR TITLE
Bump version to force reinstall files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-anki"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.3.post1"
 description = "A pytest plugin for testing Anki add-ons"
 authors = ["Aristotelis P. (Glutanimate)", "Michal Krassowski"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
#### Description

This was necessary to force a reinstall of this package on my machine when doing `pip install -r requirements/dev.txt`.

Specifying `--force-reinstall` would have worked, but bumping the version to indicate that a change occurred seems like a sensible solution, as its uncommon for packages to update without also changing their version.